### PR TITLE
fix promotion example

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -38,8 +38,8 @@ fn main() {
     // type S4 = MakeEM<S3, F4, F5>;
     // type S5 = MakeEM<S4, A6, A5>;
     // type S6 = MakeEM<S5, F5, F6>;
-    // type S7 = MakeEM<S6, A5, A6>;
-    // type S8 = MakeEM<S7, F6, F7>;
+    // type S7 = MakeEM<S6, A5, A4>;
+    // type S8 = MakeEM<S7, F6, G7>;
     // type S9 = MakeEM<S8, A4, A3>;
     // type S10 = MakeEM<S9, G7, H8, Queen>;
     // println!("{}", S10::reify());


### PR DESCRIPTION
getting the following error after 2:30min was a bit scary :sweat_smile: 
```
error[E0277]: the trait bound `<<<<<<<<state::State<White, board::Board<board::BoardRank<Filled<piece::ColoredPiece<Rook, White>>, Filled<piece::ColoredPiece<Knight, White>>, Filled<piece::ColoredPiece<Bishop, White>>, Filled<piece::ColoredPiece<piece::Queen, White>>, Filled<piece::ColoredPiece<King, White>>, Filled<piece::ColoredPiece<Bishop, White>>, Filled<piece::ColoredPiece<Knight, White>>, Filled<piece::ColoredPiece<Rook, White>>>, board::BoardRank<Filled<piece::ColoredPiece<Pawn, White>>, Filled<piece::ColoredPiece<Pawn, White>>, Filled<piece::ColoredPiece<Pawn, White>>, Filled<piece::ColoredPiece<Pawn, White>>, Filled<piece::ColoredPiece<Pawn, White>>, Filled<piece::ColoredPiece<Pawn, White>>, Filled<piece::ColoredPiece<Pawn, White>>, Filled<piece::ColoredPiece<Pawn, White>>>, board::BoardRank<board::Empty, board::Empty, board::Empty, board::Empty, board::Empty, board::Empty, board::Empty, board::Empty>, board::BoardRank<board::Empty, board::Empty, board::Empty, board::Empty, board::Empty, board::Empty, board::Empty, board::Empty>, board::BoardRank<board::Empty, board::Empty, board::Empty, board::Empty, board::Empty, board::Empty, board::Empty, board::Empty>, board::BoardRank<board::Empty, board::Empty, board::Empty, board::Empty, board::Empty, board::Empty, board::Empty, board::Empty>, board::BoardRank<Filled<piece::ColoredPiece<Pawn, Black>>, Filled<piece::ColoredPiece<Pawn, Black>>, Filled<piece::ColoredPiece<Pawn, Black>>, Filled<piece::ColoredPiece<Pawn, Black>>, Filled<piece::ColoredPiece<Pawn, Black>>, Filled<piece::ColoredPiece<Pawn, Black>>, Filled<piece::ColoredPiece<Pawn, Black>>, Filled<piece::ColoredPiece<Pawn, Black>>>, board::BoardRank<Filled<piece::ColoredPiece<Pawn, Black>>, Filled<piece::ColoredPiece<Knight, Black>>, Filled<piece::ColoredPiece<Bishop, Black>>, Filled<piece::ColoredPiece<piece::Queen, Black>>, Filled<piece::ColoredPiece<King, Black>>, Filled<piece::ColoredPiece<Bishop, Black>>, Filled<piece::ColoredPiece<Knight, Black>>, Filled<piece::ColoredPiece<Rook, Black>>>>, NoSquare, state::CastleState<True, True, True, True>> as RunMakeEM<square::Square<square::rank::R2, FF>, square::Square<square::rank::R4, FF>, NoPiece>>::Output as RunMakeEM<square::Square<square::rank::R7, FA>, square::Square<square::rank::R6, FA>, NoPiece>>::Output as RunMakeEM<square::Square<square::rank::R4, FF>, square::Square<square::rank::R5, FF>, NoPiece>>::Output as RunMakeEM<square::Square<square::rank::R6, FA>, square::Square<square::rank::R5, FA>, NoPiece>>::Output as RunMakeEM<square::Square<square::rank::R5, FF>, square::Square<square::rank::R6, FF>, NoPiece>>::Output as RunMakeEM<square::Square<square::rank::R5, FA>, square::Square<square::rank::R6, FA>, NoPiece>>::Output as RunMakeEM<square::Square<square::rank::R6, FF>, square::Square<square::rank::R7, FF>, NoPiece>>::Output as RunMakeEM<square::Square<square::rank::R4, FA>, square::Square<square::rank::R3, FA>, NoPiece>>::Output: RunMakeEM<square::Square<square::rank::R7, FG>, square::Square<square::rank::R8, FH>, piece::Queen>` is not satisfied
  --> src/main.rs:37:20
   |
37 |     println!("{}", S10::reify());
   |                    ^^^ the trait `RunMakeEM<square::Square<square::rank::R7, FG>, square::Square<square::rank::R8, FH>, piece::Queen>` is not implemented for `<<<<... as RunMakeEM<..., ..., ...>>::Output as RunMakeEM<..., ..., ...>>::Output as RunMakeEM<..., ..., ...>>::Output as RunMakeEM<..., ..., ...>>::Output`
```
with that change and https://github.com/rust-lang/rust/pull/119735 `cargo +rust1 rustc -- -Znext-solver` compiles successfully in 4m26,600s after changing the recursion limit to 1024. Unsure what exactly is responsible for the higher recursion limit requirement, but tbh, I don't care too much about that.

`RUSTFLAGS=-Znext-solver time cargo +rust1 test` takes nearly 13 minutes, can probably trivially speed this up by deduplicating obligations in the new solver as well :shrug: 